### PR TITLE
Split reviewer and submission guidelines into two documents and linke…

### DIFF
--- a/elspReviewerGuidelines.html
+++ b/elspReviewerGuidelines.html
@@ -49,7 +49,7 @@
                 <li>Consider the context of words and phrases that may change their stereotypical associations. For example, "magnetospheric driven processes"; while driven is a masuline coded word, in this example it is not describing the applicant but instead the science process.</li>
                 <li>Look for examples that have stereotypical associations or could be replaced with a different example with more positive associations. For instance, "managed group meeting" vs "Led group research meetings".</li>
                 <li>Consider the letter formatting, looking out for things like excessive blank space, unprofessional fonts, and size of signature.</li>
-                <li>Obtain a final percentage of male- and female-associated words with the Gender-Bias calculater.</li>
+                <li>Obtain a final percentage of male- and female-associated words with the Gender-Bias calculator.</li>
                 <li>Please allow 5-10 business days for a response.</li>
             </ol>
 
@@ -67,24 +67,6 @@
                <li>Affinity</li>
                <li>Halo/Horns effect</li>
            </ul>
-
-            <a href="elspContact.html">Back to Contact</a>
-
-            <h2>Guidelines for submitting letters for review</h2>
-
-            <p>Before submitting your letter for review, please ensure that you have completed the following checklist:</p>
-
-            <ul>
-                <li>Remove or redact all personal identifying information (PII) per FERPA regulations (https://www2.ed.gov/policy/gen/guid/fpco/ferpa/index.html). A common example that may be appropriate for some letters include grades.</li>
-                <li>Run the letter through a spell checker. Reviewers will also make note of spelling and grammar mistakes, but minimizing these will improve the reviewer's abillity to focus on identifiying instances of implicit bias.</li>
-                <li>Run the letter through a gender-bias calculator.</li>
-                <li>Provide the institution where the letter will be submitted.</li>
-                <li>Provide the type of position the letter is being written for.</li>
-                <li>Provide 3 suggested reviewers with their current email addresses and institutions.</li>
-                <li>Read and agree to the <a href="elspCodeOfConduct.html">code of conduct</a>.</li>
-            </ul>
-
-            <p>Please upload/send your letter for review as a text, .docx, or .pdf file to <span class="email"><a href="mailto:equitable.space.letters@gmail.com">equitable.space.letters@gmail.com</a></span>. Though we aim for a fast turn-around, nominal review times are 1 month.</p>
 
             <a href="elspContact.html">Back to Contact</a>
         </main>

--- a/elspSubmissionGuidelines.html
+++ b/elspSubmissionGuidelines.html
@@ -4,7 +4,7 @@
 <head>
     <link rel="stylesheet" type="text/css" href="css/elspStylesheet.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Ubuntu&display=swap">
-    <title>ELSP Contact Us</title>
+    <title>ELSP Submission and Review Guidelines</title>
 </head>
 
 <body>
@@ -36,17 +36,23 @@
             <hr>
         </header>
         <main>
-            <h2>Letter Review</h2>
-            <p>Helping you catch typos and unconscious biases.</p>
-            <p>In the near future, we will be accepting reference and nomination letters for review, specifically looking to address common issues introduced by unconscious biases. At this point in time, we are accepting reviewers.  If you would like to sign up to participate as a reviewer, or would like more information about what that would entail, please contact us at: <span class="email"><a href="mailto:equitable.space.letters@gmail.com">equitable.space.letters@gmail.com</a></span></p>
+            <h2>Guidelines for submitting letters for review</h2>
 
-            <h3>Guidelines</h3>
+            <p>Before submitting your letter for review, please ensure that you have completed the following checklist:</p>
+
             <ul>
-                <li><a href="elspSubmissionGuidelines.html">Submission guidelines</a></li>
-                <li><a href="elspReviewerGuidelines.html">Reviewer guidelines</a></li>
+                <li>Remove or redact all personal identifying information (PII) per FERPA regulations (https://www2.ed.gov/policy/gen/guid/fpco/ferpa/index.html). A common example that may be appropriate for some letters include grades.</li>
+                <li>Run the letter through a spell checker. Reviewers will also make note of spelling and grammar mistakes, but minimizing these will improve the reviewer's abillity to focus on identifiying instances of implicit bias.</li>
+                <li>Run the letter through a gender-bias calculator.</li>
+                <li>Provide the institution where the letter will be submitted.</li>
+                <li>Provide the type of position the letter is being written for.</li>
+                <li>Provide 3 suggested reviewers with their current email addresses and institutions.</li>
+                <li>Read and agree to the <a href="elspCodeOfConduct.html">code of conduct</a>.</li>
             </ul>
-            
 
+            <p>Please upload/send your letter for review as a text, .docx, or .pdf file to <span class="email"><a href="mailto:equitable.space.letters@gmail.com">equitable.space.letters@gmail.com</a></span>. Though we aim for a fast turn-around, nominal review times are 1 month.</p>
+
+            <a href="elspContact.html">Back to Contact</a>
         </main>
         <footer>
 

--- a/index.html
+++ b/index.html
@@ -42,7 +42,11 @@
         </p>
 
             <h2>Our Standards</h2>
-            <p> Equitable Letters in Space Physics strives to provide a welcoming environment for people to learn and grow. We are governed by a <a href="elspCodeOfConduct.html">code of conduct.</a></p>
+            <p>Equitable Letters in Space Physics (ELSP) strives to provide a welcoming environment for people to learn and grow. We are governed by a <a href="elspCodeOfConduct.html">code of conduct.</a></p>
+
+            <h2>Submitting Letters to Us</h2>
+            
+            <p>If you are writing a recommendation letter for someone you know professionally, you can send it to us <a href="elspSubmissionGuidelines.html">by following the submission guidelines here</a> and we will send it out to our reviewers. They will provide recommendations on how you can make your letter more equitable and less biased, using a combination of the techniques and resources described elsewhere on our site, with the aim to make unbiased recommendation letters more accessible to all.
 
             <h2>Our People</h2>
 
@@ -58,7 +62,7 @@
 	        </p>
 
 	        <h3>Reviewers</h3>
-	        <p>To become a reviewer, please <a href="elspContact.html">Contact us</a>.</p>
+	        <p>If you are interested in being a reviewer, please <a href="elspContact.html">contact us</a>.</p>
 	    
         </main>
         <footer>


### PR DESCRIPTION
Split reviewer and submission guidelines into two documents and linked to the submission guidelines from the homepage alongside a short blurb. Addresses #35.