### PR TITLE
MAINT: removed NRL affiliation

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
                     <li>Dr. Angeline G. Burrell, Ionospheric Researcher (<i>Exec. Dir.</i>)</li>
 	                <li>Dr. John Coxon, University of Southampton</li>
 	                <li>Dr. Alexa Halford, NASA Goddard Space Flight Center</li>
-	                <li>Dr. McArthur Jones Jr., Atmospheric Researcher</li>
+	                <li>Dr. McArthur Jones Jr., Upper Atmospheric Researcher</li>
 	                <li>Dr. Kate Zawdie, Ionospheric Researcher</li>
                 </ul>
 	        </p>

--- a/index.html
+++ b/index.html
@@ -49,11 +49,11 @@
 	        <h3>Directors</h3>
 	        <p>
 	            <ul>
-                    <li>Dr. Angeline G. Burrell, Naval Research Laboratory (<i>Exec. Dir.</i>)</li>
+                    <li>Dr. Angeline G. Burrell, Ionospheric Researcher (<i>Exec. Dir.</i>)</li>
 	                <li>Dr. John Coxon, University of Southampton</li>
 	                <li>Dr. Alexa Halford, NASA Goddard Space Flight Center</li>
-	                <li>Dr. McArthur Jones Jr., Naval Research Laboratory</li>
-	                <li>Dr. Kate Zawdie, Naval Research Laboratory</li>
+	                <li>Dr. McArthur Jones Jr., Atmospheric Researcher</li>
+	                <li>Dr. Kate Zawdie, Ionospheric Researcher</li>
                 </ul>
 	        </p>
 

--- a/index.html
+++ b/index.html
@@ -50,8 +50,8 @@
 	        <p>
 	            <ul>
                     <li>Dr. Angeline G. Burrell, Ionospheric Researcher (<i>Exec. Dir.</i>)</li>
-	                <li>Dr. John Coxon, University of Southampton</li>
-	                <li>Dr. Alexa Halford, NASA Goddard Space Flight Center</li>
+	                <li>Dr. John Coxon, University of Southampton, Magnetospheric Researcher</li>
+	                <li>Dr. Alexa Halford, NASA Goddard Space Flight Center, Magnetospheric Researcher</li>
 	                <li>Dr. McArthur Jones Jr., Upper Atmospheric Researcher</li>
 	                <li>Dr. Kate Zawdie, Ionospheric Researcher</li>
                 </ul>


### PR DESCRIPTION
Removed the NRL affiliations from the webpage.  Let me know what you think of this approach.  We can fine-tune it here or in the next PR into develop (following this one).