### PR TITLE
MAINT: fixed spelling

### DIFF
--- a/elspLetterResources.html
+++ b/elspLetterResources.html
@@ -50,7 +50,7 @@
                 <li><a target="blank" href="https://www.schoolcounselor.org/getmedia/11e887c3-bf04-4345-90c0-432f7dd8d69a/Gender-Ethnic-Bias.pdf">Gender and Ethnic Bias in Letters of Recommendation</a>: Ankos and Kretchmar (2018) in the American School Counselor Association's <i>Professional School Counseling</i> journal.</li>
                 <li><a target="blank" href="https://diversity.ldeo.columbia.edu/sites/default/files/content/Avoid%20gender%20bias%20letters%20Dutt%202019.pdf">Avoid Implicit Gender Bias in Recommendation Letters</a> - Dutt (2019) analyses 1224 letters of recommendation for gender bias.</li>
                 <li><a target="blank" href="https://alexjs.com/">alex</a>: A command-line tool and plugin for your favorite text editor designed to catch insensitive, inconsiderate writing.</li>
-                <li><a target="blank" href="https://www.autistichoya.com/p/ableist-words-and-terms-to-avoid.html">Ableism/Language</a>: A glossary of ablist words with context to improve understanding of the systemic impact of language.</li>
+                <li><a target="blank" href="https://www.autistichoya.com/p/ableist-words-and-terms-to-avoid.html">Ableism/Language</a>: A glossary of ableist words with context to improve understanding of the systemic impact of language.</li>
             </ul>
             
             <h3>Writing Better Letters</h3>


### PR DESCRIPTION
Fixed the spelling of a word to be correct.

Co-authored-by: johncoxon <john@johncoxon.co.uk>